### PR TITLE
feat: add `working_dir` argument for `external` data source

### DIFF
--- a/external/data_source.go
+++ b/external/data_source.go
@@ -22,6 +22,12 @@ func dataSource() *schema.Resource {
 				},
 			},
 
+			"working_dir": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+
 			"query": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -44,6 +50,7 @@ func dataSource() *schema.Resource {
 func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 
 	programI := d.Get("program").([]interface{})
+	workingDir := d.Get("working_dir").(string)
 	query := d.Get("query").(map[string]interface{})
 
 	// This would be a ValidateFunc if helper/schema allowed these
@@ -58,6 +65,8 @@ func dataSourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	cmd := exec.Command(program[0], program[1:]...)
+
+	cmd.Dir = workingDir
 
 	queryJson, err := json.Marshal(query)
 	if err != nil {

--- a/website/docs/data_source.html.md
+++ b/website/docs/data_source.html.md
@@ -74,6 +74,9 @@ The following arguments are supported:
   it is not necessary to escape shell metacharacters nor add quotes around
   arguments containing spaces.
 
+* `working_dir` - (Optional) Working directory of the program.
+  If not supplied, the program will run in the current directory.
+
 * `query` - (Optional) A map of string values to pass to the external program
   as the query arguments. If not supplied, the program will receive an empty
   object as its input.


### PR DESCRIPTION
Resubmitting https://github.com/hashicorp/terraform/pull/12144.
Implements #1 
